### PR TITLE
Some rephrasing and a few suggestions. :-)

### DIFF
--- a/source/use-cases/home-resolver.rst
+++ b/source/use-cases/home-resolver.rst
@@ -6,9 +6,9 @@ Resolver for Home Networks
 ==========================
 
 To start off, let's ask the all-important question "Why would you want Unbound as a resolver for your home network?" |br|
-Firstly, Unbound supports DNSSEC which, through an authentication chain, verifies that the DNS query responses you receive are unaltered, as opposed to query responses which do not have a DNSSEC record and could be changed by anyone who has access to the query.
-Secondly, by using your own resolver you stop sharing your DNS traffic with third parties (your ISP, Google, Cloudflare, Quad9, etc.) and increase your DNS privacy. While you still send out (parts of) your query unencrypted, you could configure Unbound to take it a step further, which we'll talk about in an upcoming guide.
-Lastly, when you run your own resolver your DNS cache will be locally in your network. Even though the first time you resolve a domain name may be slightly slower than using your ISP’s resolver, all subsequent queries will likely be much faster.
+Firstly, Unbound supports DNSSEC which, through an authentication chain, verifies that the DNS query responses you receive are unaltered, as opposed to query responses which are not DNSSEC-signed and could be changed by anyone who has access to the query.
+Secondly, by using your own resolver you stop sharing your DNS traffic with third parties (your ISP, Google, Cloudflare, Quad9, etc.) and increase your DNS privacy. While you still send out (parts of) your queries unencrypted, you could configure Unbound to take it a step further, which we'll talk about in an upcoming guide.
+Lastly, when you run your own resolver your DNS cache will be local to your network. Even though the first time you resolve a domain name may be slightly slower than using your ISP’s resolver, all subsequent queries for the name will likely be much faster.
 
 In this tutorial we'll look at setting up Unbound as a DNS resolver; Firstly for your own machine, and then for your entire network.
 
@@ -16,11 +16,11 @@ In this tutorial we'll look at setting up Unbound as a DNS resolver; Firstly for
 Setting up Unbound
 ------------------
 
-Unbound is a powerful validating, recursive, caching DNS resolver. It’s used by some of the biggest tech companies in the world as well as home users, who use it together with ad blockers and firewalls, or self-hosted resolvers. Setting it up for your home network can be quite simple as we’ll showcase below.
+Unbound is a powerful validating, recursive, caching DNS resolver. It’s used by some of the biggest tech companies in the world as well as small-office / home-office users, who use it together with ad blockers and firewalls, or self-hosted resolvers. Setting it up for your home network can be quite simple as we’ll showcase below.
 
-Setting up your own DNS resolver for your entire home network requires a couple of things. Namely, a recursive DNS resolver (who knew!), and a dedicated machine where the resolver runs, which is always on and accessible to the entire network. This can be as simple as a Raspberry Pi, or any other machine that is always online, connected to your home router.
+Setting up a caching DNS server for your entire home network requires a recursive DNS resolver, and a dedicated machine on which the resolver runs; this (small) system is always on and accessible to the entire network. It can be as small as a Raspberry Pi or any other available Linux/Unix machine that is always online and has Internet connectivity via your router.
 
-Because of the variety of machines that Unbound can run on we cannot create a comprehensive tutorial for all possible options. For this tutorial we will use :command:`Ubuntu 20.04.1 LTS` as a stepping stone which you could use and adapt for other machines.
+Because of the variety of machines that Unbound can run on we cannot create a comprehensive tutorial for all possible options. For this tutorial we will use :command:`Ubuntu 20.04.1 LTS` as a stepping stone you can adapt and apply to other systems.
 
 While you could download the code from GitHub and build it yourself, getting a copy can be as simple as running:
 
@@ -29,9 +29,9 @@ While you could download the code from GitHub and build it yourself, getting a c
 	sudo apt update
 	sudo apt install unbound -y
 
-This gives you a full, compiled, and running version of Unbound which behaves as a caching recursive DNS resolver out of the box for the local machine. You can check which version of Unbound you have installed with :option:`unbound -V`. The version installed will vary depending on the operating system. If the version is installed is quite old (at the time of writing it isn't) or you'd simply like to run the latest and greatest version you can download the latest release tarball from our `website <https://nlnetlabs.nl/projects/unbound/about/>`_ and build it yourself.
+This gives you a complete and running version of Unbound which behaves as a caching recursive DNS resolver out of the box for the system on which you install it. You can check which version of Unbound you have installed with :option:`unbound -V`. The version installed will vary depending on the operating system. If the version is installed is quite old (at the time of writing it isn't) or you'd simply like to run the latest and greatest version you can download the latest release tarball from our `website <https://nlnetlabs.nl/projects/unbound/about/>`_ and build it yourself.
 
-Do note that the current setup is only reachable on this machine.
+Do note that by default the DNS server will be queryable only from the local host, i.e. the system on which you installed Unbound. We will change that later.
 
 Testing the resolver locally
 ----------------------------
@@ -45,7 +45,7 @@ The command for testing locally on the Unbound machine is:
 	dig example.com @127.0.0.1
 
 Here we tell the :command:`dig` tool to look up the IP address for example.com, and to ask for this information from the server running at the IP address ``127.0.0.1``, which is where our Unbound machine is running by default.
-We can verify that Unbound has indeed answered our query instead of the default resolver that is present on Ubuntu by default. In the output of every :command:`dig` command there is an ``ANSWER SECTION`` which specifies the server which has answered the query under the ``SERVER`` entry. The entry should be:
+We can verify that Unbound has indeed answered our query instead of the default resolver that is present on Ubuntu by default. In the output of every :command:`dig` command there is an ``ANSWER SECTION`` which gives the response to the query. In the footer section of the output, the server which has answered the query under the ``SERVER`` entry. The entry will look like:
 
 .. code-block:: bash
 
@@ -75,7 +75,7 @@ While just changing this file will work as long as the machine doesn't reboot, t
 
 	rm /etc/resolv.conf
 
-With your favourite text editor (e.g. :command:`nano`), create a new file with the same name and specify the IP address that our Unbound instance is running at in the file. We also include the :option:`edns0` option as this enables header extensions used in DNSSEC and is an overall standard used in DNS nowadays. |br|
+With your favourite text editor (e.g. :command:`nano`), create a new file by that name and specify the IP address that our Unbound instance is running at in the file. We also include the :option:`edns0` option as this enables header extensions used in DNSSEC and is an overall standard used in DNS nowadays. |br|
 So with :file:`nano /etc/resolv.conf` we create the new file and enter:
 
 .. code-block:: bash
@@ -83,7 +83,7 @@ So with :file:`nano /etc/resolv.conf` we create the new file and enter:
 	nameserver 127.0.0.1
 	options edns0
 
-We then need to stop and disable the currently running pre-installed resolver. Note that you cannot visit new websites until the next step after this, as you have no DNS resolver assigned for the system.
+We then need to stop and disable the currently running pre-installed resolver. Note DNS resolution will not function until the next step is complete, as you'll have no DNS resolver assigned for the system until then.
 
 .. code-block:: bash
 
@@ -96,7 +96,7 @@ Now the operating system should use our Unbound instance as default. A quick tes
 
 	dig example.com
 
-Note that the "SERVER" section in the output from :command:`dig` should also contain the local IP address of our server.
+Note that the "SERVER" section in the footer of  :command:`dig` should also contain the local IP address of our server.
 
 .. code-block:: bash
 
@@ -119,9 +119,9 @@ To find the IP address of the machine that is running Unbound, we use:
 
 	hostname --all-ip-addresses
 
-If you just have one IP address as output from the :command:`hostname` command that will be the correct one. If you have multiple IP addresses, the easiest way to determine which IP address to use, is to find out which connection goes to your home router. Keep in mind that finding the wrong IP address here can be a source of connectivity errors further on. For the purpose of this tutorial we assume that our home router has the IP address ``10.0.0.1``, and our resolver machine (the machine that is running our Unbound instance) has IP address ``10.0.0.2``, which we will get into in the next section.
+If you just have one IP address as output from the :command:`hostname` command that will be the correct one. If you have multiple IP addresses, the easiest way to determine which IP address to use, is to find out which connection goes to your home router. Keep in mind that using the wrong IP address here can be a source of connectivity errors further on. For the purpose of this tutorial we assume that our home router has the IP address ``10.0.0.1``, and our resolver machine (the machine that is running our Unbound instance) has IP address ``10.0.0.2``, which we will get into in the next section.
 
-As a prerequisite for the next step, we need to configure our Unbound instance to be reachable from devices other than only the machine on which the Unbound is running. The full example config is almost 1200 lines long, as the capabilities of Unbound are considerable, but we won’t need nearly as much. (If you are interested, any and all configurables can be found in the extensive manual page of :manpage:`unbound.conf`).
+As a prerequisite for the next step, we need to configure our Unbound instance to be reachable from devices other than only the machine on which the Unbound is running. Unbound is a highly capable resolver, and as such has many options which can be set; the full example config is almost 1200 lines long, but we'll need but a fraction of these settings. (If you are interested, all configurables are documented in the extensive manual page of :manpage:`unbound.conf`).
 
 The default config is found at:
 
@@ -154,7 +154,7 @@ To prepare our config we are going to modify the existing config in :file:`/etc/
 If you open the file we see that there is already an “include” in there. This include enables us to do `DNSSEC <https://en.wikipedia.org/wiki/Domain_Name_System_Security_Extensions>`_, which allows Unbound to verify the source of the answers that it receives, which we want to keep in. If you don't have the file that the include links to (:file:`root.key`), it can be created using the :command:`unbound-anchor` command. |br|
 If you don't have the :file:`unbound_control.key` and :file:`unbound_control.pem` files, when you're building Unbound from source for example, the command to create these is: :command:`unbound-control-setup`.
 
-Using the text editor again, we can then add the minimal config as shown above, making any changes to the access control where needed. Do note that we strongly recommend keeping the :command:`include` that is already in the file (such as in the above config). We also add the :command:`remote-control` in the config to enable controlling Unbound using :command:`unbound-control` command which is useful if you want to modify the config later on. When you are happy with your config, we can check it for mistakes with the :command:`unbound-checkconf` command:
+Using the text editor again, we can then add the minimal config as shown above, making any changes to the access control where needed. Do note that we strongly recommend keeping the :command:`include` that is already in the file (such as in the above config). We also add the :command:`remote-control` in the config to enable controlling Unbound using :command:`unbound-control` command which is useful if you want to modify the config later on. When we've modified the configuration we check it for mistakes with the :command:`unbound-checkconf` command:
 
 .. code-block:: bash
 
@@ -183,14 +183,14 @@ So now we have a DNS resolver which should be reachable from within the network.
 
 	dig example.com @10.0.0.2
 
-This should give the same result, including the ``SERVER`` entry, as the query from the local test above.
+This should give the same result. The ``SERVER`` entry in the footer will reflect from which server the response was received.
 
 Where it all comes together
 ---------------------------
 
 We should now have a functioning DNS resolver that is accessible to all machines in our network (make sure you do before you continue). 
 
-The next step then becomes a little tricky as there are many options and variations possible. We have a choice of which machines in our network will be using our configured DNS resolver. This can range from a single machine to all the machines that are connected. Since this tutorial cannot (and does not try to) be comprehensive for the range of choices, we will look at some of the basic examples which you can implement and expand on.
+The next step then is a little tricky as there are many options and variations possible. We have a choice of which machines in our network will be using our configured DNS resolver. This can range from a single machine to all the machines that are connected. Since this tutorial cannot (and does not try to) be comprehensive for the range of choices, we will look at some of the basic examples which you can implement and expand on.
 
 Most machines when they first connect to a network get a “recommended resolver” from your router using :abbr:`DHCP (Dynamic Host Configuration Protocol)`. To change this, we need to log into the router. To find the IP address of our home router which is likely be under :option:`default gateway`:
 


### PR DESCRIPTION
I've taken the liberty of doing a bit of rephrasing; I hope that's ok.

There are certain portions of this documentation which can be improved upon:

1. This page uses 10/8 as example addressing. In my experience, SOHO routers will typically use 192.168/16, in which case I think it'd be less confusing to newcomers (and this document definitely targets those) to use addresses they may recognize from their own setups.
2. unbound-anchor and -control-setup are mentioned but not otherwise explained or demonstrated. If Ubuntu requires them to be used, they should be explained; otherwise simplify by dropping their discussion
3. "Do note that we strongly recommend keeping the include that is already in the file (such as in the above config)" I don't see an "include" there
4. "need to find the IP address of the resolver machine". The user has done that previously and knows it's 10.0.0.2
5. "When you've found the IP address of your home router," is illogical: it was earlier assumed this is 10.0.0.1. Actually I think this needs to be put above, i.e. start with that part (find the addressing first, and then start configuring)