### PR TITLE
unbound-control-setup doesn’t create the config file

### DIFF
--- a/source/getting-started/configuration.rst
+++ b/source/getting-started/configuration.rst
@@ -150,9 +150,7 @@ default install directory. The default install directory is
 ``/usr/local/etc/unbound/`` on most systems, but some distributions may put it
 in ``/etc/unbound/`` or ``/var/lib/unbound``.
 
-Apart from an extensive configuration file, with just about all the possible
-configuration options, :command:`unbound-control-setup` creates the
-cryptographic keys necessary for the control option:
+:command:`unbound-control-setup` creates the cryptographic keys necessary for the control option:
 
 .. code-block:: bash
 


### PR DESCRIPTION
I cannot confirm that unbound-control-setup creates the configuration file:

```console
$ mkdir /tmp/u
$ unbound-control-setup -d /tmp/u
$ ls /tmp/u
unbound_control.key     unbound_control.pem     unbound_server.key      unbound_server.pem
```