### PR TITLE
Add missing requirement, correct command typo, and correct invalid config syntax snippet.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ sphinx-version-warning==1.1.2
 sphinx-tabs==3.2.0
 sphinx-copybutton==0.4.0
 sphinx-notfound-page
+sphinx-rtd-theme

--- a/source/getting-started/configuration.rst
+++ b/source/getting-started/configuration.rst
@@ -220,7 +220,7 @@ file.
 Note that on some systems the ``/usr/local/etc/unbound/`` directory might be
 write-protected.
 
-If the :command:`unbound-control-setup` command fails due to the insufficient
+If the :command:`unbound-anchor` command fails due to the insufficient
 permissions, run the command as the correct user, here we use the user
 ``unbound`` as this is the default user.
 

--- a/source/topics/core/monitoring.rst
+++ b/source/topics/core/monitoring.rst
@@ -64,10 +64,13 @@ your system. The ``statefile`` is a temporary file.
 
 .. code-block:: text
 
-   [unbound*] user root env.statefile
-   /usr/local/var/munin/plugin-state/unbound-state env.unbound_conf
-   /usr/local/etc/unbound/unbound.conf env.unbound_control
-   /usr/local/sbin/unbound-control env.spoof_warn 1000 env.spoof_crit 100000
+   [unbound*]
+   user root
+   env.statefile /usr/local/var/munin/plugin-state/unbound-state
+   env.unbound_conf /usr/local/etc/unbound/unbound.conf
+   env.unbound_control /usr/local/sbin/unbound-control
+   env.spoof_warn 1000
+   env.spoof_crit 100000
 
 Restart the munin-node daemon. Munin will automatically pick up the new graph
 and plot it with ``rrdtool``.


### PR DESCRIPTION
* Add a missing dependency needed for building html docs (sphinx-rtd-theme).
* Correct a typo where command from previous section is used in an example.
* Correct syntax errors in munin configuration file snippet caused by newlines being converted to whitespace.

Tested with: munin 2.0.73 