### PR TITLE
Correct typos.

### DIFF
--- a/source/developer/libunbound-tutorial/examine-results.rst
+++ b/source/developer/libunbound-tutorial/examine-results.rst
@@ -162,7 +162,7 @@ of failure, mostly a failure at the DNS server.
 The example prints all the data elements and their length.
 
 Here are some other results that you can get. The first is an alias, with
-several addresses, and the second is a nonexistant name:
+several addresses, and the second is a nonexistent name:
 
 .. code-block:: text
 

--- a/source/manpages/unbound-anchor.rst
+++ b/source/manpages/unbound-anchor.rst
@@ -177,7 +177,7 @@ The available options are:
        unbound-anchor goes to the network itself for these roots, to resolve
        the server (:option:`-u` option) and to check the root DNSKEY records.
        It does so, because the tool when used for bootstrapping the recursive
-       reolver, cannot use that recursive resolver itself because it is
+       resolver, cannot use that recursive resolver itself because it is
        bootstrapping that server.
 
 .. option:: -R

--- a/source/reference/history/index.rst
+++ b/source/reference/history/index.rst
@@ -9,7 +9,7 @@ implementation was based on a prototype written in Java. It was released in May
 2008 with this :download:`press release<files/Unbound_Press_Release.pdf>`.
 
 This section contains several historic documents. There are also presentations
-about the intial Unbound design delivered at :download:`IETF 67
+about the initial Unbound design delivered at :download:`IETF 67
 <files/ietf67-design-02.pdf>` and :download:`RIPE 56
 <files/ripe56_unbound_02.pdf>`. The :download:`Windows Vista install
 guide <files/unbound-windows-manual-02.pdf>` is also available as a PDF.

--- a/source/reference/history/info-timeout-server-selection.rst
+++ b/source/reference/history/info-timeout-server-selection.rst
@@ -95,7 +95,7 @@ When a domain starts to become unresponsive, it is probed.  In this regime
 only one request is allowed to probe to a particular IP.  This conserves
 resources, as other requests are turned away, and do to not use up
 port-numbers, sockets and requestlist elements.  Also it lowers the
-traffic towards the destination (that is apparantly having trouble),
+traffic towards the destination (that is apparently having trouble),
 which may help it get back up.
 
 An IP address is in the probing regime if it fits the following criteria.
@@ -223,7 +223,7 @@ Control
 
 The timeout behaviour can be controlled and configured.
 
-The configation consists of the size of the infra-cache (please allow
+The configuration consists of the size of the infra-cache (please allow
 sufficient elements to store information about IP addresses).  And the
 infra-ttl time can be configured.  By setting the infra-ttl lower,
 unbound will probe servers that are not responsive more aggressively.

--- a/source/reference/history/prototype-resolver.rst
+++ b/source/reference/history/prototype-resolver.rst
@@ -56,7 +56,7 @@ Prototype?
 Java, while a fine, fine language, isn't what we envision as the final
 implementation language of the non-prototype resolver.  That would be C.  For
 the prototype, however, Java was chosen because of the excellent `DNSjava
-<http://www.dnsjava.org>`_ library and the familarity with the same on the part
+<http://www.dnsjava.org>`_ library and the familiarity with the same on the part
 of one of the main developers.
 
 The intent is to use a prototype to explore and validate a particular design for

--- a/source/reference/rfc-compliance.rst
+++ b/source/reference/rfc-compliance.rst
@@ -12,7 +12,7 @@ Internet drafts that have been implemented in Unbound.
 
 ============== ====
 :rfc:`1034`    Domain Names – Concepts and Facilities
-:rfc:`1035`    Domain Names – Implementation and Specifciation
+:rfc:`1035`    Domain Names – Implementation and Specification
 :rfc:`1101`    DNS Encoding of Network Names and Other Types
 :rfc:`1123`    Requirements for Internet Hosts -- Application and Support
 :rfc:`1183`    New DNS RR Definitions

--- a/source/reference/todo.rst
+++ b/source/reference/todo.rst
@@ -4,7 +4,7 @@ Docs To-Do List
 Since the first release in 2007, the documentation of Unbound has been
 maintained with a heavy focus on :doc:`manual pages</manpages/unbound>`. As
 the resolver has become more versatile and feature-rich over the years, the
-NLnet Labs team decided to add this documention, providing installation guides
+NLnet Labs team decided to add this documentation, providing installation guides
 for different platforms, practical use cases, and background information. 
 
 The to-do list below provides an overview if the the topics we still have to


### PR DESCRIPTION
Found by:
find build/html/ -name '*.html'|xargs -n1 links -dump|hunspell -d en_GB -l