### PR TITLE
Fix GitHub repository name in Unbound documentation

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -165,7 +165,7 @@ html_context = {
         'conf_py_path': "/source/",
 
         'github_user': "NLnetLabs",
-        'github_repo': "unbound",
+        'github_repo': "unbound-manual",
         'github_version': os.environ.get("READTHEDOCS_GIT_IDENTIFIER", "main"),
         'display_github': True,
         'READTHEDOCS': True,


### PR DESCRIPTION
Fix broken 'Edit in GitHub' links in Unbound documentation.

Fixes:  https://github.com/NLnetLabs/unbound-manual/issues/52