### PR TITLE
Improve Ubuntu compiling from source setup

### DIFF
--- a/source/use-cases/local-stub.rst
+++ b/source/use-cases/local-stub.rst
@@ -265,9 +265,9 @@ and copy the file contents below:
     Wants=nss-lookup.target
 
     [Service]
-    Type=simple
+    Type=exec
     Restart=on-failure
-    EnvironmentFile=-/usr/local/etc/unbound
+    EnvironmentFile=-/usr/local/etc/unbound/unbound
     ExecStart=/usr/local/sbin/unbound -d -p $DAEMON_OPTS
     ExecReload=+/bin/kill -HUP $MAINPID
 
@@ -276,8 +276,10 @@ and copy the file contents below:
 
 Note that in this file ``systemctl`` uses the default config location. This 
 location is different depending on the installation method used. In this case the 
-default config file is located at :file:`/usr/local/etc/unbound`. We need to copy
-the config that we are going to use here.
+default config file is located at :file:`/usr/local/etc/unbound` (normally located at :file:`/etc/unbound`). We need to copy
+the config that we are going to use here. 
+You might also want to create the environment file :file:`/usr/local/etc/unbound/unbound` for setting the
+`DAEMON_OPTS` environment variable. Omit the `-p` option if you wish to create a PID file.
 
 Once you have your config copied in the right location, we need to make sure the 
 system can find it. 

--- a/source/use-cases/local-stub.rst
+++ b/source/use-cases/local-stub.rst
@@ -276,7 +276,7 @@ and copy the file contents below:
 
 Note that in this file ``systemctl`` uses the default config location. This 
 location is different depending on the installation method used. In this case the 
-default config file is located at :file:`/usr/local/etc/unbound` (normally located at :file:`/etc/unbound`). We need to copy
+default config file is located at :file:`/usr/local/etc/unbound` (some distributions use  :file:`/etc/unbound` for their Unbound package). We need to copy
 the config that we are going to use here. 
 You might also want to create the environment file :file:`/usr/local/etc/unbound/unbound_env` for setting the
 `DAEMON_OPTS` environment variable. Omit the `-p` option if you wish to create a PID file.

--- a/source/use-cases/local-stub.rst
+++ b/source/use-cases/local-stub.rst
@@ -279,7 +279,8 @@ location is different depending on the installation method used. In this case th
 default config file is located at :file:`/usr/local/etc/unbound` (some distributions use  :file:`/etc/unbound` for their Unbound package). We need to copy
 the config that we are going to use here. 
 You might also want to create the environment file :file:`/usr/local/etc/unbound/unbound_env` for setting the
-`DAEMON_OPTS` environment variable. Omit the `-p` option if you wish to create a PID file.
+`DAEMON_OPTS` environment variable.
+With this systemd service file there is no longer a need for a PID file (`-p` option above) since service management is handled by systemd. You can omit the `-p` option if you still wish to create a PID file.
 
 Once you have your config copied in the right location, we need to make sure the 
 system can find it. 

--- a/source/use-cases/local-stub.rst
+++ b/source/use-cases/local-stub.rst
@@ -267,7 +267,7 @@ and copy the file contents below:
     [Service]
     Type=exec
     Restart=on-failure
-    EnvironmentFile=-/usr/local/etc/unbound/unbound
+    EnvironmentFile=-/usr/local/etc/unbound/unbound_env
     ExecStart=/usr/local/sbin/unbound -d -p $DAEMON_OPTS
     ExecReload=+/bin/kill -HUP $MAINPID
 

--- a/source/use-cases/local-stub.rst
+++ b/source/use-cases/local-stub.rst
@@ -278,7 +278,7 @@ Note that in this file ``systemctl`` uses the default config location. This
 location is different depending on the installation method used. In this case the 
 default config file is located at :file:`/usr/local/etc/unbound` (normally located at :file:`/etc/unbound`). We need to copy
 the config that we are going to use here. 
-You might also want to create the environment file :file:`/usr/local/etc/unbound/unbound` for setting the
+You might also want to create the environment file :file:`/usr/local/etc/unbound/unbound_env` for setting the
 `DAEMON_OPTS` environment variable. Omit the `-p` option if you wish to create a PID file.
 
 Once you have your config copied in the right location, we need to make sure the 


### PR DESCRIPTION
- [Its better to use type `exec`](https://systemd-by-example.com/system/part-3-example-06-type-exec) instead of `simple` when using Systemd.
-  Fix the environment file (it was just pointing to the directory 😢 ). 
- Generally explain it all better.